### PR TITLE
fix: fetch 的 config入参为空，给config.agent赋值报错

### DIFF
--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -3,7 +3,7 @@ import HttpsProxyAgent from 'https-proxy-agent'
 import { getProxy } from './tools'
 
 // 使用 fetch + 代理
-export async function fetch(url: string, config?: RequestInit) {
+export async function fetch(url: string, config: RequestInit = {}) {
     const proxy = getProxy()
     if (proxy) {
         config.agent = new HttpsProxyAgent(proxy)


### PR DESCRIPTION
tcb init 拉取模板时,fetch第二个config参数为空，命令行存在代理，config不存在
TypeError: Cannot set property 'agent' of undefined