### PR TITLE
support: 版本发布脚本在选择错误时，支持重新开始

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,9 +1067,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -1080,6 +1080,14 @@
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "dev": true
+        }
       }
     },
     "acorn-jsx": {
@@ -2914,14 +2922,6 @@
         "acorn": "^7.1.0",
         "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -5662,9 +5662,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "ws": {

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,6 +3,22 @@ const inquirer = require('inquirer')
 const semver = require('semver')
 const package = require('../package.json')
 const { exec } = require('child_process')
+
+async function retry() {
+    const confirm = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'try',
+            message: '是否重新尝试发布？',
+            default: false
+        }
+    ])
+
+    if (confirm.try) {
+        publish()
+    }
+}
+
 async function publish() {
     const config = await inquirer.prompt([
         {
@@ -24,6 +40,7 @@ async function publish() {
 
     if (config.isLatest && config.version === 'prerelease') {
         console.log('PreRelease版本不能发布正式版！')
+        setImmediate(retry)
         return
     }
 


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/26399528/77142265-866d6900-6aba-11ea-9d54-4e3e90f13467.png)

## Now

![image](https://user-images.githubusercontent.com/26399528/77142289-97b67580-6aba-11ea-8cb7-8b26cecc6173.png)

## What I do 

在下次eventloop中插入retry函数，好处：
- 不改动publish入参和返回
- 避免多次尝试情况下的递归开销
